### PR TITLE
replace TextWizard with built-in hashlib

### DIFF
--- a/apkutils/__init__.py
+++ b/apkutils/__init__.py
@@ -1,4 +1,5 @@
 import binascii
+import hashlib
 import re
 import xml
 from xml.parsers.expat import ExpatError
@@ -12,7 +13,6 @@ from apkutils.axml.axmlparser import AXML
 from apkutils.dex.dexparser import DexFile
 from bs4 import BeautifulSoup
 from cigam import Magic
-from TextWizard import hash
 
 __version__ = '0.8.1'
 
@@ -208,7 +208,7 @@ class APK:
         self.trees = {}
         for pre, _, node in RenderTree(root):
             if node.height > height:
-                key = hash.hash(serialize_node(node), 'md5')
+                key = hashlib.md5(serialize_node(node).encode('utf-8')).hexdigest()
                 if key in self.trees:
                     self.trees[key].append(node)
                 else:

--- a/requirment.txt
+++ b/requirment.txt
@@ -2,5 +2,4 @@ anytree
 cigam
 pyelftools
 pyopenssl
-TextWizard
 xmltodict

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 setup(
     name="apkutils",
 
-    version='0.8.1',
+    version='0.8.2',
 
     description=("Utils for parsing apk."),
     long_description=read('README.rst'),
@@ -37,7 +37,6 @@ setup(
         "cigam",
         "pyelftools",
         "pyopenssl",
-        "TextWizard",
         "xmltodict",
         "beautifulsoup4",
     ],


### PR DESCRIPTION
For whatever reason, the TextWizard project on pypi.org has been removed breaking apkutils since its dependencies are not being able to be downloaded anymore. There's basically no reason to use TextWizard in this project anyway. I replaced it with python's built-in hashlib which is actually being used by Textwizard as well.